### PR TITLE
remove ars elemental runtime deps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -167,7 +167,7 @@ dependencies {
 
     // cyanide to debug worldgen, localRuntime configuration won't mark is a dependency
     // localRuntime "curse.maven:cyanide-541676:5782674"
-    runtimeOnly("com.alexthw.ars_elemental:ars_elemental-${minecraft_version}:${elemental_version}") { transitive = false }
+
 
 
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,4 @@ nuggets_version=1.0.7.38
 jei_version=19.21.0.247
 curios_version=9.2.2+1.21.1
 geckolib_version=4.7.2
-elemental_version=0.7.6.0.92
+


### PR DESCRIPTION
I'm not 100% sure if it's needed, but if it's included then Ars Affinity cannot be used alongside Ars Elemental 0.7.5